### PR TITLE
Download file from url instead of from file system for IOS

### DIFF
--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -70,6 +70,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
 
         if (options[@"attachment"] && options[@"attachment"][@"path"] && options[@"attachment"][@"type"]){
             NSString *attachmentPath = [RCTConvert NSString:options[@"attachment"][@"path"]];
+            NSURL *attachmentURL = [NSURL URLWithString:attachmentPath]
             NSString *attachmentType = [RCTConvert NSString:options[@"attachment"][@"type"]];
             NSString *attachmentName = [RCTConvert NSString:options[@"attachment"][@"name"]];
 
@@ -79,7 +80,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
             }
 
             // Get the resource path and read the file using NSData
-            NSData *fileData = [NSData dataWithContentsOfFile:attachmentPath];
+            NSData *fileData = [NSData dataWithContentsOfURL:attachmentURL];
 
             // Determine the MIME type
             NSString *mimeType;

--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -71,7 +71,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
         if (options[@"attachment"] && options[@"attachment"][@"path"] && options[@"attachment"][@"type"]){
             NSString *attachmentPath = [RCTConvert NSString:options[@"attachment"][@"path"]];
             NSURL *attachmentURL = [NSURL URLWithString:attachmentPath]
-            NSString *attachmentType = [RCTConvert NSString:options[@"attachment"][@"type"]];
+            NSString *mimeType = [RCTConvert NSString:options[@"attachment"][@"type"]];
             NSString *attachmentName = [RCTConvert NSString:options[@"attachment"][@"name"]];
 
             // Set default filename if not specificed
@@ -81,56 +81,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
 
             // Get the resource path and read the file using NSData
             NSData *fileData = [NSData dataWithContentsOfURL:attachmentURL];
-
-            // Determine the MIME type
-            NSString *mimeType;
-            
-            /*
-             * Add additional mime types and PR if necessary. Find the list
-             * of supported formats at http://www.iana.org/assignments/media-types/media-types.xhtml
-             */
-            if ([attachmentType isEqualToString:@"jpg"]) {
-                mimeType = @"image/jpeg";
-            } else if ([attachmentType isEqualToString:@"png"]) {
-                mimeType = @"image/png";
-            } else if ([attachmentType isEqualToString:@"doc"]) {
-                mimeType = @"application/msword";
-            } else if ([attachmentType isEqualToString:@"docx"]) {
-                mimeType = @"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-            } else if ([attachmentType isEqualToString:@"ppt"]) {
-                mimeType = @"application/vnd.ms-powerpoint";
-            } else if ([attachmentType isEqualToString:@"pptx"]) {
-                mimeType = @"application/vnd.openxmlformats-officedocument.presentationml.presentation";
-            } else if ([attachmentType isEqualToString:@"html"]) {
-                mimeType = @"text/html";
-            } else if ([attachmentType isEqualToString:@"csv"]) {
-                mimeType = @"text/csv";
-            } else if ([attachmentType isEqualToString:@"pdf"]) {
-                mimeType = @"application/pdf";
-            } else if ([attachmentType isEqualToString:@"vcard"]) {
-                mimeType = @"text/vcard";
-            } else if ([attachmentType isEqualToString:@"json"]) {
-                mimeType = @"application/json";
-            } else if ([attachmentType isEqualToString:@"zip"]) {
-                mimeType = @"application/zip";
-            } else if ([attachmentType isEqualToString:@"text"]) {
-                mimeType = @"text/*";
-            } else if ([attachmentType isEqualToString:@"mp3"]) {
-                mimeType = @"audio/mpeg";
-            } else if ([attachmentType isEqualToString:@"wav"]) {
-                mimeType = @"audio/wav";
-            } else if ([attachmentType isEqualToString:@"aiff"]) {
-                mimeType = @"audio/aiff";
-            } else if ([attachmentType isEqualToString:@"flac"]) {
-                mimeType = @"audio/flac";
-            } else if ([attachmentType isEqualToString:@"ogg"]) {
-                mimeType = @"audio/ogg";
-            } else if ([attachmentType isEqualToString:@"xls"]) {
-                mimeType = @"application/vnd.ms-excel";     
-            } else if ([attachmentType isEqualToString:@"xlsx"]) {
-                mimeType = @"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-            }
-
+          
             // Add attachment
             [mail addAttachmentData:fileData mimeType:mimeType fileName:attachmentName];
         }


### PR DESCRIPTION
Supports download of files from our filepicker api instead of the device file system

We also have the mime type already as part of the attachment data passed from the backend. We will use that instead of using the file extension to determine the mime type in react-native-mail